### PR TITLE
including langchain-openai package in toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ dependencies = [
     "mcp",
     "langchain>=0.1.0",
     "langchain-community>=0.0.10",
+    "langchain-openai>=0.3.12",
     "websockets>=12.0",
     "aiohttp>=3.9.0",
     "pydantic>=2.0.0",


### PR DESCRIPTION
While trying to reproduce the minimal example in the README.md, I noticed it requires some imports:

```python
import asyncio
from dotenv import load_dotenv
from langchain_openai import ChatOpenAI
from mcp_use import MCPAgent, MCPClient
```

However, the package `langchain_openai` is missing in `pyproject.toml`.

This PR includes `langchain_openai` in `pyproject.toml`