### PR TITLE
feat: tool blacklist

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,25 +307,58 @@ if __name__ == "__main__":
     asyncio.run(main())
 ```
 
-## Roadmap
+# Tool Access Control
+
+MCP-Use allows you to restrict which tools are available to the agent, providing better security and control over agent capabilities:
+
+```python
+import asyncio
+from mcp_use import MCPAgent, MCPClient
+from langchain_openai import ChatOpenAI
+
+async def main():
+    # Create client
+    client = MCPClient.from_config_file("config.json")
+
+    # Create agent with restricted tools
+    agent = MCPAgent(
+        llm=ChatOpenAI(model="gpt-4"),
+        client=client,
+        disallowed_tools=["file_system", "network"]  # Restrict potentially dangerous tools
+    )
+
+    # Run a query with restricted tool access
+    result = await agent.run(
+        "Find the best restaurant in San Francisco"
+    )
+    print(result)
+
+    # Clean up
+    await client.close_all_sessions()
+
+if __name__ == "__main__":
+    asyncio.run(main())
+```
+
+# Roadmap
 
 <ul>
 <li>[x] Multiple Servers at once </li>
-<li>[ ] Test remote connectors (http, ws)</li>
+<li>[x] Test remote connectors (http, ws)</li>
 <li>[ ] ... </li>
 </ul>
 
-## Contributing
+# Contributing
 
 We love contributions! Feel free to open issues for bugs or feature requests.
 
-## Requirements
+# Requirements
 
 - Python 3.11+
 - MCP implementation (like Playwright MCP)
 - LangChain and appropriate model libraries (OpenAI, Anthropic, etc.)
 
-## Citation
+# Citation
 
 If you use MCP-Use in your research or project, please cite:
 
@@ -339,6 +372,6 @@ If you use MCP-Use in your research or project, please cite:
 }
 ```
 
-## License
+# License
 
 MIT

--- a/docs/api-reference/introduction.mdx
+++ b/docs/api-reference/introduction.mdx
@@ -127,24 +127,26 @@ agent = MCPAgent(
     memory_enabled=True,
     system_prompt=None,
     system_prompt_template=None,
-    additional_instructions=None
+    additional_instructions=None,
+    disallowed_tools=None
 )
 ```
 
-| Parameter                 | Type                | Required | Default | Description                                |
-| ------------------------- | ------------------- | -------- | ------- | ------------------------------------------ |
-| `llm`                     | BaseLanguageModel   | Yes      | -       | Any LangChain-compatible language model    |
-| `client`                  | MCPClient           | No       | None    | The MCPClient instance                     |
-| `connectors`              | list[BaseConnector] | No       | None    | List of connectors if not using client     |
-| `server_name`             | str                 | No       | None    | Name of the server to use                  |
-| `max_steps`               | int                 | No       | 5       | Maximum number of steps the agent can take |
-| `auto_initialize`         | bool                | No       | False   | Whether to initialize automatically        |
-| `memory_enabled`          | bool                | No       | True    | Whether to enable memory                   |
-| `system_prompt`           | str                 | No       | None    | Custom system prompt                       |
-| `system_prompt_template`  | str                 | No       | None    | Custom system prompt template              |
-| `additional_instructions` | str                 | No       | None    | Additional instructions for the agent      |
-| `session_options`         | dict                | No       | {}      | Additional options for session creation    |
-| `output_parser`           | OutputParser        | No       | None    | Custom output parser for LLM responses     |
+| Parameter                 | Type                | Required | Default | Description                                                  |
+| ------------------------- | ------------------- | -------- | ------- | ------------------------------------------------------------ |
+| `llm`                     | BaseLanguageModel   | Yes      | -       | Any LangChain-compatible language model                      |
+| `client`                  | MCPClient           | No       | None    | The MCPClient instance                                       |
+| `connectors`              | list[BaseConnector] | No       | None    | List of connectors if not using client                       |
+| `server_name`             | str                 | No       | None    | Name of the server to use                                    |
+| `max_steps`               | int                 | No       | 5       | Maximum number of steps the agent can take                   |
+| `auto_initialize`         | bool                | No       | False   | Whether to initialize automatically                          |
+| `memory_enabled`          | bool                | No       | True    | Whether to enable memory                                     |
+| `system_prompt`           | str                 | No       | None    | Custom system prompt                                         |
+| `system_prompt_template`  | str                 | No       | None    | Custom system prompt template                                |
+| `additional_instructions` | str                 | No       | None    | Additional instructions for the agent                        |
+| `session_options`         | dict                | No       | {}      | Additional options for session creation                      |
+| `output_parser`           | OutputParser        | No       | None    | Custom output parser for LLM responses                       |
+| `disallowed_tools`        | list[str]           | No       | None    | List of tool names that should not be available to the agent |
 
 **When to use different parameters**:
 
@@ -176,6 +178,11 @@ agent = MCPAgent(
 - **session_options**:
   - Customize timeout for long-running server operations
   - Set retry parameters for unstable connections
+- **disallowed_tools**:
+  - Use to restrict which tools the agent can access
+  - Helpful for security or to limit agent capabilities
+  - Useful when certain tools might be dangerous or unnecessary for a specific task
+  - Can be updated after initialization using `set_disallowed_tools()`
 
 ### Core Methods
 
@@ -233,6 +240,39 @@ history = agent.get_history()
 - For debugging agent behavior
 - When implementing custom logging
 - To provide context for follow-up queries
+
+#### set_disallowed_tools
+
+Sets the list of tools that should not be available to the agent.
+
+```python
+agent.set_disallowed_tools(["tool1", "tool2"])
+```
+
+| Parameter          | Type      | Required | Description                                     |
+| ------------------ | --------- | -------- | ----------------------------------------------- |
+| `disallowed_tools` | list[str] | Yes      | List of tool names that should not be available |
+
+**When to use**:
+
+- To restrict access to specific tools for security reasons
+- To limit agent capabilities for specific tasks
+- To prevent the agent from using potentially dangerous tools
+- Note: Changes take effect on next initialization
+
+#### get_disallowed_tools
+
+Gets the list of tools that are not available to the agent.
+
+```python
+disallowed = agent.get_disallowed_tools()
+```
+
+**When to use**:
+
+- To check which tools are currently restricted
+- For debugging or auditing purposes
+- To verify tool restrictions before running the agent
 
 ## Configuration Details
 
@@ -383,3 +423,34 @@ This approach is useful when:
 - The MCP server returns structured data that needs special handling
 - You need to extract specific information from responses
 - You're integrating with custom or specialized MCP servers
+
+### Restricting Tool Access
+
+Control which tools are available to the agent:
+
+```python
+from mcp_use import MCPAgent, MCPClient
+from langchain_openai import ChatOpenAI
+
+# Create agent with restricted tools
+agent = MCPAgent(
+    llm=ChatOpenAI(model="gpt-4o"),
+    client=client,
+    disallowed_tools=["file_system", "network", "shell"]  # Restrict potentially dangerous tools
+)
+
+# Update restrictions after initialization
+agent.set_disallowed_tools(["file_system", "network", "shell", "database"])
+await agent.initialize()  # Reinitialize to apply changes
+
+# Check current restrictions
+restricted_tools = agent.get_disallowed_tools()
+print(f"Restricted tools: {restricted_tools}")
+```
+
+This approach is useful when:
+
+- You need to restrict access to sensitive operations
+- You want to limit the agent's capabilities for specific tasks
+- You're concerned about security implications of certain tools
+- You want to focus the agent on specific functionality

--- a/docs/essentials/configuration.mdx
+++ b/docs/essentials/configuration.mdx
@@ -96,28 +96,25 @@ Here's a basic example of how to configure an MCP server:
 ### Multiple Server Configuration
 
 You can configure multiple MCP servers in a single configuration file, allowing you to use different servers for different tasks or combine their capabilities (e.g.):
+
 ```json
 {
-        "mcpServers": {
-            "airbnb": {
-                "command": "npx",
-                "args": ["-y", "@openbnb/mcp-server-airbnb", "--ignore-robots-txt"],
-            },
-            "playwright": {
-                "command": "npx",
-                "args": ["@playwright/mcp@latest"],
-                "env": {"DISPLAY": ":1"},
-            },
-            "filesystem": {
-                "command": "npx",
-                "args": [
-                    "-y",
-                    "@modelcontextprotocol/server-filesystem",
-                    "/home/pietro/projects/mcp-use/",
-                ],
-            },
-        }
+  "mcpServers": {
+    "airbnb": {
+      "command": "npx",
+      "args": ["-y", "@openbnb/mcp-server-airbnb", "--ignore-robots-txt"]
+    },
+    "playwright": {
+      "command": "npx",
+      "args": ["@playwright/mcp@latest"],
+      "env": { "DISPLAY": ":1" }
+    },
+    "filesystem": {
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-filesystem", "/home/pietro/projects/mcp-use/"]
     }
+  }
+}
 ```
 
 For a complete example of using multiple servers, see the [multi-server example](https://github.com/pietrozullo/mcp-use/blob/main/examples/multi_server_example.py) in our repository.
@@ -146,7 +143,8 @@ agent = MCPAgent(
     auto_initialize=True,
     memory_enabled=True,
     system_prompt="Custom instructions for the agent",
-    additional_instructions="Additional guidelines for specific tasks"
+    additional_instructions="Additional guidelines for specific tasks",
+    disallowed_tools=["file_system", "network", "shell"]  # Restrict potentially dangerous tools
 )
 ```
 
@@ -162,6 +160,35 @@ agent = MCPAgent(
 - `system_prompt`: Custom system prompt (optional)
 - `system_prompt_template`: Custom system prompt template (optional)
 - `additional_instructions`: Additional instructions for the agent (optional)
+- `disallowed_tools`: List of tool names that should not be available to the agent (optional)
+
+### Tool Access Control
+
+You can restrict which tools are available to the agent for security or to limit its capabilities:
+
+```python
+# Create agent with restricted tools
+agent = MCPAgent(
+    llm=ChatOpenAI(model="gpt-4o"),
+    client=client,
+    disallowed_tools=["file_system", "network", "shell"]  # Restrict potentially dangerous tools
+)
+
+# Update restrictions after initialization
+agent.set_disallowed_tools(["file_system", "network", "shell", "database"])
+await agent.initialize()  # Reinitialize to apply changes
+
+# Check current restrictions
+restricted_tools = agent.get_disallowed_tools()
+print(f"Restricted tools: {restricted_tools}")
+```
+
+This feature is useful for:
+
+- Restricting access to sensitive operations
+- Limiting agent capabilities for specific tasks
+- Preventing the agent from using potentially dangerous tools
+- Focusing the agent on specific functionality
 
 ## Error Handling
 

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -82,6 +82,45 @@ if __name__ == "__main__":
     asyncio.run(main())
 ```
 
+## Restricting Tool Access
+
+You can control which tools are available to the agent:
+
+```python
+import asyncio
+import os
+from dotenv import load_dotenv
+from langchain_openai import ChatOpenAI
+from mcp_use import MCPAgent, MCPClient
+
+async def main():
+    # Load environment variables
+    load_dotenv()
+
+    # Create MCPClient from config file
+    client = MCPClient.from_config_file("browser_mcp.json")
+
+    # Create LLM
+    llm = ChatOpenAI(model="gpt-4o")
+
+    # Create agent with restricted tools
+    agent = MCPAgent(
+        llm=llm,
+        client=client,
+        max_steps=30,
+        disallowed_tools=["file_system", "network"]  # Restrict potentially dangerous tools
+    )
+
+    # Run the query
+    result = await agent.run(
+        "Find the best restaurant in San Francisco USING GOOGLE SEARCH",
+    )
+    print(f"\nResult: {result}")
+
+if __name__ == "__main__":
+    asyncio.run(main())
+```
+
 ## Available MCP Servers
 
 mcp_use supports various MCP servers:


### PR DESCRIPTION
[Idea from] : https://www.reddit.com/r/mcp/comments/1juucpe/is_there_a_tool_to_manage_an_allowdeny_list_of/
Added the disallowed_tools functionality to restrict which tools are available to agents, along with comprehensive documentation:

-  Implemented disallowed_tools parameter in MCPAgent initialization

- Added set_disallowed_tools() and get_disallowed_tools() methods

- Updated API Reference with parameter details and methods

- Added examples to Quickstart guide

- Included feature in README.md

- Added detailed configuration section in essentials/configuration.mdx

This PR enhances security and control capabilities by allowing users to restrict access to sensitive operations and limit agent capabilities.