### PR TITLE
修復 Windows 系統上找不到命令路徑的問題

### DIFF
--- a/mcp_use/connectors/stdio.py
+++ b/mcp_use/connectors/stdio.py
@@ -5,7 +5,11 @@ This module provides a connector for communicating with MCP implementations
 through the standard input/output streams.
 """
 
+import os
+import shutil
+import subprocess
 import sys
+import platform
 
 from mcp import ClientSession, StdioServerParameters
 
@@ -28,6 +32,7 @@ class StdioConnector(BaseConnector):
         args: list[str] | None = None,
         env: dict[str, str] | None = None,
         errlog=sys.stderr,
+        resolve_command_path: bool = True,
     ):
         """Initialize a new stdio connector.
 
@@ -36,12 +41,160 @@ class StdioConnector(BaseConnector):
             args: Optional command line arguments.
             env: Optional environment variables.
             errlog: Stream to write error output to.
+            resolve_command_path: Whether to resolve the command path at initialization time.
+                                 This can help catch command not found errors early.
         """
         super().__init__()
         self.command = command
         self.args = args or []  # Ensure args is never None
         self.env = env
         self.errlog = errlog
+
+        # Optionally resolve the command path at initialization time
+        if resolve_command_path:
+            try:
+                resolved_command = self._find_command_path(command)
+                if resolved_command != command:
+                    logger.debug(f"Resolved command '{command}' to '{resolved_command}'")
+                    self.command = resolved_command
+            except Exception as e:
+                # Just log a warning, don't fail initialization
+                logger.warning(f"Failed to resolve command path for '{command}': {e}")
+
+    def _find_command_path(self, command: str) -> str:
+        """Find the full path to a command, handling platform-specific issues.
+
+        Args:
+            command: The command to find
+
+        Returns:
+            The full path to the command or the original command if not found
+
+        This is particularly important for Windows where commands like 'npx' might not be
+        directly accessible without specifying the full path or using the appropriate extension.
+        """
+        # If it's already a full path, return it
+        if os.path.isfile(command) and os.access(command, os.X_OK):
+            return command
+
+        # On Windows, we need to handle this differently
+        if platform.system() == "Windows":
+            # Try to find the command using 'where' (Windows equivalent of 'which')
+            try:
+                # Check if it's in PATH
+                result = subprocess.run(
+                    ["where", command],
+                    capture_output=True,
+                    text=True,
+                    check=False
+                )
+                if result.returncode == 0 and result.stdout.strip():
+                    # Return the first match
+                    return result.stdout.strip().split('\n')[0]
+
+                # Special handling for npm/npx commands which might be in node_modules
+                if command in ["npm", "npx"]:
+                    # Common locations for npm/npx on Windows
+                    possible_paths = [
+                        os.path.join(os.environ.get("APPDATA", ""), "npm"),
+                        os.path.join(os.environ.get("ProgramFiles", ""), "nodejs"),
+                        os.path.join(os.environ.get("ProgramFiles(x86)", ""), "nodejs"),
+                        # Add Node.js global install directory
+                        os.path.join(os.environ.get("USERPROFILE", ""), "AppData", "Roaming", "npm"),
+                        # Add potential npm global prefix locations
+                        os.path.join(os.environ.get("USERPROFILE", ""), ".npm-global"),
+                        os.path.join(os.environ.get("USERPROFILE", ""), "npm-global"),
+                    ]
+
+                    # Try to get npm prefix path
+                    try:
+                        npm_prefix_result = subprocess.run(
+                            ["cmd", "/c", "npm config get prefix"],
+                            capture_output=True,
+                            text=True,
+                            check=False
+                        )
+                        if npm_prefix_result.returncode == 0 and npm_prefix_result.stdout.strip():
+                            npm_prefix = npm_prefix_result.stdout.strip()
+                            possible_paths.append(npm_prefix)
+                            possible_paths.append(os.path.join(npm_prefix, "node_modules", ".bin"))
+                    except Exception as e:
+                        logger.debug(f"Failed to get npm prefix: {e}")
+
+                    # Check for various extensions on Windows
+                    extensions = [".cmd", ".exe", ".bat", ".ps1"]
+                    for base_path in possible_paths:
+                        # First check without extension
+                        cmd_path = os.path.join(base_path, command)
+                        if os.path.isfile(cmd_path):
+                            return cmd_path
+
+                        # Then check with various extensions
+                        for ext in extensions:
+                            cmd_path = os.path.join(base_path, f"{command}{ext}")
+                            if os.path.isfile(cmd_path):
+                                return cmd_path
+
+                    # Also check with various extensions using 'where' command
+                    for ext in extensions:
+                        try:
+                            result = subprocess.run(
+                                ["where", f"{command}{ext}"],
+                                capture_output=True,
+                                text=True,
+                                check=False
+                            )
+                            if result.returncode == 0 and result.stdout.strip():
+                                return result.stdout.strip().split('\n')[0]
+                        except Exception as e:
+                            logger.debug(f"Error checking for {command}{ext}: {e}")
+            except Exception as e:
+                logger.warning(f"Error finding command path for '{command}': {e}")
+        else:
+            # On Unix-like systems, use 'which'
+            try:
+                path = shutil.which(command)
+                if path:
+                    return path
+
+                # Special handling for macOS
+                if platform.system() == "Darwin":
+                    # Check common macOS locations for npm/npx
+                    if command in ["npm", "npx"]:
+                        # Common locations for npm/npx on macOS
+                        possible_paths = [
+                            "/usr/local/bin",
+                            "/opt/homebrew/bin",  # For Apple Silicon (M1/M2) Macs
+                            os.path.expanduser("~/node_modules/.bin"),
+                            os.path.expanduser("~/.npm-global/bin"),
+                            "/opt/local/bin",  # MacPorts
+                        ]
+
+                        # Try to get npm prefix path
+                        try:
+                            npm_prefix_result = subprocess.run(
+                                ["npm", "config", "get", "prefix"],
+                                capture_output=True,
+                                text=True,
+                                check=False
+                            )
+                            if npm_prefix_result.returncode == 0 and npm_prefix_result.stdout.strip():
+                                npm_prefix = npm_prefix_result.stdout.strip()
+                                possible_paths.append(os.path.join(npm_prefix, "bin"))
+                        except Exception as e:
+                            logger.debug(f"Failed to get npm prefix on macOS: {e}")
+
+                        # Check each possible path
+                        for base_path in possible_paths:
+                            cmd_path = os.path.join(base_path, command)
+                            if os.path.isfile(cmd_path) and os.access(cmd_path, os.X_OK):
+                                return cmd_path
+            except Exception as e:
+                logger.warning(f"Error finding command path for '{command}': {e}")
+
+        # If we couldn't find it, return the original command
+        # This will likely fail, but it's the best we can do
+        return command
 
     async def connect(self) -> None:
         """Establish a connection to the MCP implementation."""
@@ -51,9 +204,14 @@ class StdioConnector(BaseConnector):
 
         logger.debug(f"Connecting to MCP implementation: {self.command}")
         try:
+            # Find the full path to the command
+            command_path = self._find_command_path(self.command)
+            if command_path != self.command:
+                logger.debug(f"Using resolved command path: {command_path}")
+
             # Create server parameters
             server_params = StdioServerParameters(
-                command=self.command, args=self.args, env=self.env
+                command=command_path, args=self.args, env=self.env
             )
 
             # Create and start the connection manager

--- a/tests/connectors/__init__.py
+++ b/tests/connectors/__init__.py
@@ -1,0 +1,1 @@
+# Connectors tests package

--- a/tests/connectors/test_stdio.py
+++ b/tests/connectors/test_stdio.py
@@ -1,0 +1,83 @@
+"""
+Tests for the StdioConnector class.
+"""
+
+import os
+import platform
+import pytest
+from unittest.mock import patch, MagicMock
+
+from mcp_use.connectors.stdio import StdioConnector
+
+
+class TestStdioConnector:
+    """Tests for the StdioConnector class."""
+
+    def test_init(self):
+        """Test initialization of StdioConnector."""
+        connector = StdioConnector(command="test_command", args=["arg1", "arg2"])
+        assert connector.command == "test_command"
+        assert connector.args == ["arg1", "arg2"]
+        assert connector.env is None
+
+    def test_init_with_resolve_path_disabled(self):
+        """Test initialization with resolve_command_path=False."""
+        with patch.object(StdioConnector, "_find_command_path") as mock_find:
+            connector = StdioConnector(
+                command="test_command",
+                args=["arg1"],
+                resolve_command_path=False
+            )
+            mock_find.assert_not_called()
+            assert connector.command == "test_command"
+
+    def test_init_with_resolve_path_enabled(self):
+        """Test initialization with resolve_command_path=True."""
+        with patch.object(StdioConnector, "_find_command_path") as mock_find:
+            mock_find.return_value = "/resolved/path/test_command"
+            connector = StdioConnector(
+                command="test_command",
+                args=["arg1"],
+                resolve_command_path=True
+            )
+            mock_find.assert_called_once_with("test_command")
+            assert connector.command == "/resolved/path/test_command"
+
+    def test_find_command_path_windows(self):
+        """Test _find_command_path on Windows."""
+        if platform.system() != "Windows":
+            pytest.skip("Test only applicable on Windows")
+
+        with patch("platform.system", return_value="Windows"):
+            with patch("subprocess.run") as mock_run:
+                # Mock the 'where' command result
+                mock_result = MagicMock()
+                mock_result.returncode = 0
+                mock_result.stdout = "C:\\path\\to\\npx.cmd\n"
+                mock_run.return_value = mock_result
+
+                connector = StdioConnector(command="npx", resolve_command_path=False)
+                result = connector._find_command_path("npx")
+
+                assert result == "C:\\path\\to\\npx.cmd"
+                mock_run.assert_called_with(
+                    ["where", "npx"],
+                    capture_output=True,
+                    text=True,
+                    check=False
+                )
+
+    def test_find_command_path_macos(self):
+        """Test _find_command_path on macOS."""
+        if platform.system() != "Darwin":
+            pytest.skip("Test only applicable on macOS")
+
+        with patch("shutil.which") as mock_which:
+            # Test when shutil.which finds the command
+            mock_which.return_value = "/usr/local/bin/npx"
+
+            connector = StdioConnector(command="npx", resolve_command_path=False)
+            result = connector._find_command_path("npx")
+
+            assert result == "/usr/local/bin/npx"
+            mock_which.assert_called_with("npx")


### PR DESCRIPTION
## 問題描述

在 Windows 系統上運行時，當嘗試執行 `npx` 命令時，會出現 `FileNotFoundError: [WinError 2] The system cannot find the file specified` 錯誤。

## 解決方案

1. 添加對 Windows 系統的特殊處理，以正確解析命令路徑
2. 支持多種可能的擴展名（.cmd, .exe, .bat, .ps1）
3. 添加對 macOS 系統的特殊處理，特別是 Apple Silicon 處理器
4. 在初始化時嘗試解析命令路徑，以提前捕獲錯誤
5. 改進錯誤處理和日誌記錄

## 測試

添加了單元測試來驗證修復的正確性。

修復 #48